### PR TITLE
Added author email and website

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,9 @@
 {
-    "name": "Enclosure Fan",
-    "author": "Pheneeny",
-    "version": "1.0.0",
-    "description": "Control an enclosure exhaust fan",
-    "api": 4
+  "name": "Enclosure Fan",
+  "author": "Pheneeny",
+  "author_email": "pheneeny@gmail.com",
+  "website": "https://github.com/Pheneeny/CuraPlugin-EnclosureFan",
+  "version": "1.0.0",
+  "description": "Control an enclosure exhaust fan",
+  "api": 4
 }

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "author": "Pheneeny",
   "author_email": "pheneeny@gmail.com",
   "website": "https://github.com/Pheneeny/CuraPlugin-EnclosureFan",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Control an enclosure exhaust fan",
   "api": 4
 }


### PR DESCRIPTION
I've already added this info to the Cura plugin repository, but I've created this PR so that you repository stays up to date. I will also be adding the email and website requirements to our GitHub wiki (don't worry, it wasn't there before, so this omission was not your mistake).